### PR TITLE
Add email notifications for activity registration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
+- Email notifications on signup and cancellation (configurable SMTP)
 
 ## Getting Started
 
@@ -31,6 +33,21 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                     |
+
+## Email configuration
+
+Set the following environment variables to enable email delivery. If they are not provided, the API will skip sending emails and log a notice instead.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `SMTP_HOST` | SMTP server hostname | _required_ |
+| `SMTP_PORT` | SMTP server port | `587` |
+| `SMTP_USERNAME` | SMTP username | _empty_ |
+| `SMTP_PASSWORD` | SMTP password | _empty_ |
+| `FROM_EMAIL` | Sender email address | _required_ |
+| `FROM_NAME` | Friendly sender name | `Mergington High School Activities` |
+| `SMTP_USE_TLS` | Enable TLS (`true`/`false`) | `true` |
 
 ## Data Model
 


### PR DESCRIPTION
## Summary
- add SMTP-based email notifications for activity signup and cancellation using FastAPI background tasks
- document email configuration and unregister endpoint in the API README

## Testing
- not run (not present)
